### PR TITLE
AutomateChests: Add support for big chests (and update to 1.6)

### DIFF
--- a/AutomateChests/AutomateChests.csproj
+++ b/AutomateChests/AutomateChests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
 

--- a/AutomateChests/IGenericModConfigMenuApi.cs
+++ b/AutomateChests/IGenericModConfigMenuApi.cs
@@ -23,26 +23,15 @@ namespace AutomateChests
         /// <param name="text">The paragraph text to display.</param>
         void AddParagraph(IManifest mod, Func<string> text);
 
-        /// <summary>Add a boolean option at the current position in the form.</summary>
+        /// <summary>Add a string option at the current position in the form.</summary>
         /// <param name="mod">The mod's manifest.</param>
         /// <param name="getValue">Get the current value from the mod config.</param>
         /// <param name="setValue">Set a new value in the mod config.</param>
         /// <param name="name">The label text to show in the form.</param>
         /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="allowedValues">The values that can be selected, or <c>null</c> to allow any.</param>
+        /// <param name="formatAllowedValue">Get the display text to show for a value from <paramref name="allowedValues"/>, or <c>null</c> to show the values as-is.</param>
         /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
-        void AddBoolOption(IManifest mod, Func<bool> getValue, Action<bool> setValue, Func<string> name, Func<string> tooltip = null, string fieldId = null);
-
-        /// <summary>Add an integer option at the current position in the form.</summary>
-        /// <param name="mod">The mod's manifest.</param>
-        /// <param name="getValue">Get the current value from the mod config.</param>
-        /// <param name="setValue">Set a new value in the mod config.</param>
-        /// <param name="name">The label text to show in the form.</param>
-        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
-        /// <param name="min">The minimum allowed value, or <c>null</c> to allow any.</param>
-        /// <param name="max">The maximum allowed value, or <c>null</c> to allow any.</param>
-        /// <param name="interval">The interval of values that can be selected.</param>
-        /// <param name="formatValue">Get the display text to show for a value, or <c>null</c> to show the number as-is.</param>
-        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
-        void AddNumberOption(IManifest mod, Func<int> getValue, Action<int> setValue, Func<string> name, Func<string> tooltip = null, int? min = null, int? max = null, int? interval = null, Func<int, string> formatValue = null, string fieldId = null);
+        void AddTextOption(IManifest mod, Func<string> getValue, Action<string> setValue, Func<string> name, Func<string> tooltip = null, string[] allowedValues = null, Func<string, string> formatAllowedValue = null, string fieldId = null);
     }
 }

--- a/AutomateChests/ModConfig.cs
+++ b/AutomateChests/ModConfig.cs
@@ -8,7 +8,6 @@ namespace AutomateChests
 {
     internal class ModConfig
     {
-        public bool ActivationItemIsBigCraftable { get; set; } = true;
-        public int ActivationItemIndex { get; set; } = 275;
+        public string ActivationItemId { get; set; } = "(BC)275";
     }
 }

--- a/AutomateChests/ModEntry.cs
+++ b/AutomateChests/ModEntry.cs
@@ -59,19 +59,11 @@ namespace AutomateChests
             configMenu.AddParagraph(
                 mod: this.ModManifest,
                 text: () => "The following config is for controlling the item required to enable a chest for automation, and the item you get back when undoing the chest automation. If you change the config while having chests automated, if you remove the item you will get the new configs item instead");
-            // add some config options
-            configMenu.AddBoolOption(
+            configMenu.AddTextOption(
                 mod: this.ModManifest,
-                name: () => "Activation Item is BigCraftable",
-                tooltip: () => "This controls whether to interpret ActivationItemIndex as a BigCraftable or as an Object",
-                getValue: () => this.Config.ActivationItemIsBigCraftable,
-                setValue: value => this.Config.ActivationItemIsBigCraftable = value
-            );
-            configMenu.AddNumberOption(
-                mod: this.ModManifest,
-                name: () => "Activation Item Index",
-                getValue: () => this.Config.ActivationItemIndex,
-                setValue: value => this.Config.ActivationItemIndex = value
+                name: () => "Activation Item ID",
+                getValue: () => this.Config.ActivationItemId,
+                setValue: value => this.Config.ActivationItemId = value
             );
         }
 
@@ -86,11 +78,11 @@ namespace AutomateChests
                 return;
 
             Game1.currentLocation.objects.TryGetValue(e.Cursor.GrabTile, out SObject obj);
-            if (obj != null && obj is Chest { SpecialChestType: Chest.SpecialChestTypes.None} chest)
+            if (obj != null && obj is Chest { SpecialChestType: Chest.SpecialChestTypes.None or Chest.SpecialChestTypes.BigChest } chest)
             {
                 var heldItem = Game1.player.ActiveObject;
                 // if the player is holding a hopper and the chest isn't tagged by us, it should be now
-                if (heldItem != null && heldItem.ParentSheetIndex == Config.ActivationItemIndex && heldItem.bigCraftable.Value == Config.ActivationItemIsBigCraftable && !chest.modData.ContainsKey(this.ModDataFlag))
+                if (heldItem != null && heldItem.QualifiedItemId == Config.ActivationItemId && !chest.modData.ContainsKey(this.ModDataFlag))
                 {
                     chest.Tint = Color.DarkViolet;
                     chest.modData[this.ModDataFlag] = "1";
@@ -110,14 +102,7 @@ namespace AutomateChests
                     chest.heldObject.Value = null;
                     chest.modData.Remove(this.ModDataFlag);
 
-                    Item item;
-                    if (Config.ActivationItemIsBigCraftable)
-                    {
-                        item = new SObject(Vector2.Zero, Config.ActivationItemIndex, false);
-                    } else
-                    {
-                        item = new SObject(Config.ActivationItemIndex, 1, false);
-                    }
+                    Item item = ItemRegistry.Create(Config.ActivationItemId);
                     Game1.player.addItemByMenuIfNecessary(item);
 
                     Game1.playSound("shiny4");

--- a/AutomateChests/ObjectPatches.cs
+++ b/AutomateChests/ObjectPatches.cs
@@ -29,7 +29,7 @@ namespace AutomateChests
                 {
                     var obj = container.Location.getObjectAtTile(__result.TileArea.X, __result.TileArea.Y);
                     // if it is a normal ordinary chest and isn't flagged by AutomateChests, it is no longer a valid container (but if it is flagged, don't alter it (keeping it automated)
-                    if (obj is Chest { SpecialChestType: Chest.SpecialChestTypes.None } chest && !chest.modData.ContainsKey("SinZ.AutomateChests"))
+                    if (obj is Chest { SpecialChestType: Chest.SpecialChestTypes.None or Chest.SpecialChestTypes.BigChest } chest && !chest.modData.ContainsKey("SinZ.AutomateChests"))
                     {
                         __result = null;
                     }

--- a/AutomateChests/manifest.json
+++ b/AutomateChests/manifest.json
@@ -1,16 +1,16 @@
 {
   "Name": "AutomateChests",
   "Author": "SinZ",
-  "Version": "1.1.0",
+  "Version": "2.0.0",
   "Description": "Changes Automate to only use this mods defined chest instead of normal chests for storage",
   "UniqueID": "SinZ.AutomateChests",
   "EntryDll": "AutomateChests.dll",
-  "MinimumApiVersion": "3.0.0",
+  "MinimumApiVersion": "4.0.0",
   "UpdateKeys": [ "Nexus:11727" ],
   "Dependencies": [
     {
       "UniqueID": "Pathoschild.Automate",
-      "MinimumVersion": "1.25.3"
+      "MinimumVersion": "2.0.0"
     }
   ]
 }


### PR DESCRIPTION
First off, thank you for the mod! It still works in 1.6, but the new version introduces big chests, which will automatically be enabled for automation because this mod only considers regular chests. This PR changes that so big chests will also need the activation item to be enabled for automation.

Also upgrade the code to 1.6; with the new `QualifiedItemId` system there should be no need for the `ActivationItemIsBigCraftable` settings.

Known issue: in-place upgrading an Automate-enabled regular chest to big chest will not inherit the config in `modData`, and the activation item is lost as a result. The activation item must be removed from a regular chest before it's upgraded to a big chest.